### PR TITLE
installation: fix wlctl installation

### DIFF
--- a/wazo_load_cli/setup.py
+++ b/wazo_load_cli/setup.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
-# Copyright 2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2023-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from setuptools import setup
+from setuptools import find_packages, setup
 
 setup(
     name='wlctl',
@@ -16,6 +16,7 @@ setup(
     install_requires=[
         'Click',
     ],
+    packages=find_packages(),
     entry_points={
         'console_scripts': [
             'wlctl = wlctl.main:cli',


### PR DESCRIPTION
without the packages argument the installation will only work with the -e option