### PR TITLE
WAZO 4386 bump mypy 1.19.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.991
+    rev: v1.19.1
     hooks:
       - id: mypy
         exclude: "setup.py"

--- a/wazo_load_pilot/wlpd/plugins/fleet/http.py
+++ b/wazo_load_pilot/wlpd/plugins/fleet/http.py
@@ -1,4 +1,4 @@
-# Copyright 2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2024-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import asyncio
@@ -23,7 +23,7 @@ async def run_on_all_gateways(config: dict, command: str) -> dict:
     errors = []
 
     for i, result in enumerate(results, 1):
-        if isinstance(result, Exception):
+        if isinstance(result, BaseException):
             print('Task %d failed: %s', i, str(result))
             errors.append(str(result))
         elif result.exit_status != 0:


### PR DESCRIPTION
- **pre-commit: bump mypy**
- **typing: handle BaseException in run_on_all_gateways**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Pre-commit and typing updates**
> 
> - Bumps pre-commit `mypy` hook to `v1.19.1` in `.pre-commit-config.yaml`.
> - In `wlpd/plugins/fleet/http.py`, updates `run_on_all_gateways` to check `isinstance(result, BaseException)` when aggregating async results.
> - Updates copyright header years.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b2b565b8450acb2235e6a7fe7f75bc084a348fb9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->